### PR TITLE
Add intermediate measure for state vector simulation

### DIFF
--- a/acqdp/tensor_network/kahypar_order_finder.py
+++ b/acqdp/tensor_network/kahypar_order_finder.py
@@ -110,7 +110,8 @@ class KHPOrderFinder(OrderFinder):
                     break
         return order, counter
 
-    def find_order(self, graph):
+    def find_order(self, tn):
+        graph = tn
         graph_copy = graph._expand_and_delta()
         graph_copy.fix()
         init_order, counter = self._simplify(graph_copy)

--- a/acqdp/tensor_network/order_finder.py
+++ b/acqdp/tensor_network/order_finder.py
@@ -111,7 +111,7 @@ class SlicedOrderFinder(OrderFinder):
 
     def find_order(self, tn, **kwargs):
         tn = tn._expand_and_delta()
-        order_gen = self.base_order_finder.find_order(graph=tn)
+        order_gen = self.base_order_finder.find_order(tn=tn)
         next(order_gen)
         while True:
             res = self.slicer.slice(tn, order_gen)

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
         'numexpr',
         'matplotlib',
         'opt_einsum',
-        'kahypar',
+        'kahypar >= 1.1.0',
         'cma',
         'jax',
         'jaxlib',

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -256,3 +256,84 @@ class CircuitTestCase(unittest.TestCase):
         for i in range(3):
             c_manual.append(noise_channel, [i])
         self.assertTrue(np.allclose(c_noisy.tensor_density.contract(), c_manual.tensor_density.contract()))
+
+    def test_collapse(self):
+        c = circuit.Circuit()
+        c.append(circuit.ZeroState, [0])
+        c.append(circuit.ZeroState, [1])
+        c.append(circuit.ZeroState, [2])
+        for i in range(3):
+            c.append(circuit.HGate, [i])
+        c.append(circuit.CZGate, [0, 1])
+        c.append(circuit.CZGate, [0, 2])
+        c.collapse()
+        self.assertTrue(
+            np.allclose(c.tensor_pure.contract(),
+                        c.collapse().tensor_pure.contract()))
+
+        c = circuit.Circuit()
+        c.append(circuit.ZeroState, [0])
+        c.append(circuit.ZeroState, [1])
+        c.append(circuit.ZeroState, [2])
+        for i in range(3):
+            c.append(circuit.HGate, [i])
+        c.append(circuit.CZGate, [0, 1])
+        c.append(circuit.CZGate, [0, 2])
+        noise_channel = circuit.Depolarization(0.5, 0.1, 0.15)
+        c_noisy = noise.add_noise(c, noise_channel)
+        self.assertTrue(
+            np.allclose(c_noisy.tensor_density.contract(),
+                        c_noisy.collapse().tensor_density.contract()))
+
+    def test_measure(self):
+        c = circuit.Circuit()
+        c.append(circuit.ZeroState, [0])
+        b, d = c.measure(0)
+        self.assertEqual(b, 0)
+        self.assertTrue(
+            np.allclose(d.tensor_pure.contract(), np.array([1, 0])))
+
+        c = circuit.Circuit()
+        c.append(circuit.ZeroState, [0])
+        b, d = c.measure(0, True)
+        self.assertEqual(b, 0)
+        self.assertTrue(
+            np.allclose(d.tensor_pure.contract(), np.array(1)))
+
+        c = circuit.Circuit()
+        c.append(circuit.ZeroState, [0])
+        c.append(circuit.ZeroState, [1])
+        c.append(circuit.HGate, [0])
+        c.append(circuit.CNOTGate, [0, 1])
+        b, c = c.measure(0)
+        e, c = c.measure(1)
+        self.assertEqual(b, e)
+
+        c = circuit.Circuit()
+        c.append(circuit.ZeroState, [0])
+        c.append(circuit.ZeroState, [1])
+        c.append(circuit.HGate, [0])
+        c.append(circuit.CNOTGate, [0, 1])
+        b, c = c.measure(0, True)
+        e, c = c.measure(1, True)
+        self.assertEqual(b, e)
+
+        c = circuit.Circuit()
+        c.append(circuit.ZeroState, [0])
+        c.append(circuit.ZeroState, [1])
+        c.append(circuit.HGate, [0])
+        c.append(circuit.CNOTGate, [0, 1])
+        b, c = c.measure(0, collapse=False)
+        e, c = c.measure(1, collapse=False)
+        self.assertEqual(b, e)
+
+        c = circuit.Circuit()
+        c.append(circuit.ZeroState, [0])
+        c.append(circuit.ZeroState, [1])
+        c.append(circuit.HGate, [0])
+        c.append(circuit.CNOTGate, [0, 1])
+        b, c = c.measure(0, True, False)
+        e, c = c.measure(1, True, False)
+        self.assertEqual(b, e)
+
+        pass


### PR DESCRIPTION
Add two methods `measure` and `collapse` in `acqdp.circuit.Circuit`.

The method `measure` of a circuit takes an argument specifying the index of the qubit to be measured, and returns a random measurement result and the corresponding conditional quantum state. Two optional arguments include `remove_qubit`, indicating whether the qubit being measured is to be removed from the system, and `collapse`, indicating whether the returned conditional state still preserves the tensor network structure.

The method `collapse` evaluates a quantum circuit as a tensor network, and replace the tensor network structure with the value of it. Doing this simplifies the quantum circuit and makes state vector update more efficient. `collapse` now only supports quantum circuits that are states, i.e. quantum operators with no input wires.